### PR TITLE
Fix :: Android 알림 허용 모달 미표시 문제 수정

### DIFF
--- a/Android/app/src/main/kotlin/Main.kt
+++ b/Android/app/src/main/kotlin/Main.kt
@@ -104,16 +104,13 @@ open class MainActivity: AppCompatActivity {
 
         AppDelegate.shared.onLaunch()
 
-        // Example of requesting permissions on startup.
-        // These must match the permissions in the AndroidManifest.xml file.
-        //let permissions = listOf(
-        //    Manifest.permission.ACCESS_COARSE_LOCATION,
-        //    Manifest.permission.ACCESS_FINE_LOCATION
-        //    Manifest.permission.CAMERA,
-        //    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-        //)
-        //let requestTag = 1
-        //ActivityCompat.requestPermissions(self, permissions.toTypedArray(), requestTag)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ActivityCompat.requestPermissions(
+                this,
+                kotlin.arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                1
+            )
+        }
     }
 
     override fun onStart() {


### PR DESCRIPTION
## Summary
- `POST_NOTIFICATIONS` 권한이 `AndroidManifest.xml`에 선언만 되어 있고 런타임 요청 코드가 주석 처리된 채 누락되어 있었음
- Android 13(API 33)+ 에서는 런타임 권한 요청이 필수이므로 `MainActivity.onCreate()`에서 `ActivityCompat.requestPermissions()` 호출 추가
- Skip의 `arrayOf()` 충돌 방지를 위해 `kotlin.arrayOf()` 명시적 사용

## Test plan
- [ ] Android 13 이상 기기에서 앱 최초 설치 후 실행 시 알림 허용 다이얼로그 표시 확인
- [ ] 알림 허용/거부 후 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* Android 13 이상 기기에서 알림 권한 요청이 정상 작동하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->