### PR TITLE
Fix :: 로그인 후 강제 종료 문제 수정

### DIFF
--- a/Sources/PiCKAdmin/Features/Main/Views/MainTabView.swift
+++ b/Sources/PiCKAdmin/Features/Main/Views/MainTabView.swift
@@ -4,8 +4,10 @@ struct MainTabView: View {
     @Environment(\.appRouter) var router: AppRouter
 
     var body: some View {
-        @Bindable var bindableRouter = router
-        TabView(selection: $bindableRouter.selectedTab) {
+        TabView(selection: Binding(
+            get: { router.selectedTab },
+            set: { router.selectedTab = $0 }
+        )) {
             NavigationStack {
                 SchoolMealView()
                     .toolbarBackground(Color.white, for: .navigationBar)


### PR DESCRIPTION
## Summary
- `MainTabView.body` 내 `@Bindable var bindableRouter = router` 인라인 선언이 Skip/Android Compose 재조합(recomposition) 시 충돌을 일으키던 문제 수정
- 로그아웃 후 재로그인, 또는 로그인 실패 후 재시도 시 `MainTabView`가 재생성될 때 발생하던 강제 종료 해결
- `@Bindable` 대신 `Binding(get:set:)`으로 교체하여 Skip 호환성 확보

## Test plan
- [ ] 앱 최초 설치 후 로그인 정상 동작 확인
- [ ] 로그인 실패(잘못된 비밀번호) 후 재시도 시 정상 로그인 확인
- [ ] 로그아웃 후 재로그인 시 강제 종료 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 탭 뷰의 라우팅 바인딩 구조를 개선했습니다.

이 변경사항은 내부 구현 최적화로, 사용자 경험에 직접적인 영향은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->